### PR TITLE
Update the type of timestamp from double to long in EventDetail

### DIFF
--- a/src/main/java/com/meituan/lyrebird/client/api/EventDetail.java
+++ b/src/main/java/com/meituan/lyrebird/client/api/EventDetail.java
@@ -10,7 +10,7 @@ public class EventDetail {
     @JsonProperty("event_id")
     private String eventID;
     private String id;
-    private double timestamp;
+    private long timestamp;
 
     public String getChannel() {
         return channel;
@@ -44,11 +44,11 @@ public class EventDetail {
         this.id = id;
     }
 
-    public double getTimestamp() {
+    public long getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(double timestamp) {
+    public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
     }   
 }


### PR DESCRIPTION
修复消息总线中时间戳因 long 转 double 导致精度丢失，造成的时间戳取值不准确的问题。(在 JAVA 中映射时间戳的基本数据类型应该使用 long 长整型，System.currentTimeMillis() 中返回的类型同样是 long，和 JAVA 原生保持一直)