### PR TITLE
Request和Response声明数据时，去掉显式new HashMap，否在客户在用的时候，被限制为HashMap类型数据，改为灵活一…

### DIFF
--- a/src/main/java/com/meituan/lyrebird/client/api/Request.java
+++ b/src/main/java/com/meituan/lyrebird/client/api/Request.java
@@ -7,19 +7,19 @@ import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Request {
-    private Map<String, String> headers = new HashMap<>();
+    private Map headers;
     private String method;
-    private Map<String, String> query = new HashMap<>();
+    private Map query;
     private String url;
     private String host;
     private String path;
-    private Map<String, ?> data = new HashMap<>();
+    private Map data;
 
-    public Map<String, String> getHeaders() {
+    public Map getHeaders() {
         return headers;
     }
 
-    public void setHeaders(Map<String, String> headers) {
+    public void setHeaders(Map headers) {
         this.headers = headers;
     }
 
@@ -31,11 +31,11 @@ public class Request {
         this.method = method;
     }
 
-    public Map<String, String> getQuery() {
+    public Map getQuery() {
         return query;
     }
 
-    public void setQuery(Map<String, String> query) {
+    public void setQuery(Map query) {
         this.query = query;
     }
 
@@ -63,11 +63,11 @@ public class Request {
         this.path = path;
     }
 
-    public Map<String, ?> getData() {
+    public Map getData() {
         return data;
     }
 
-    public void setData(Map<String, ?> data) {
+    public void setData(Map data) {
         this.data = data;
     }
 }

--- a/src/main/java/com/meituan/lyrebird/client/api/Response.java
+++ b/src/main/java/com/meituan/lyrebird/client/api/Response.java
@@ -1,6 +1,5 @@
 package com.meituan.lyrebird.client.api;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -9,8 +8,8 @@ import com.jayway.jsonpath.JsonPath;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Response {
     private int code;
-    private Map<String, String> headers = new HashMap<>();
-    private Map<String, ?> data = new HashMap<>();
+    private Map headers;
+    private Map data;
 
     public int getCode() {
         return code;
@@ -20,11 +19,11 @@ public class Response {
         this.code = code;
     }
 
-    public Map<String, String> getHeaders() {
+    public Map getHeaders() {
         return headers;
     }
 
-    public void setHeaders(Map<String, String> headers) {
+    public void setHeaders(Map headers) {
         this.headers = headers;
     }
 
@@ -33,7 +32,7 @@ public class Response {
      * 
      * @return 服务端返回数据映射的 Java 对象
      */
-    public Map<String, ?> getData() {
+    public Map getData() {
         return data;
     }
 
@@ -60,7 +59,7 @@ public class Response {
         return JsonPath.parse(data).read(jsonPath, type);
     }
 
-    public void setData(Map<String, ?> data) {
+    public void setData(Map data) {
         this.data = data;
     }
 }

--- a/src/test/java/com/meituan/lyrebird/test/TestFunctional.java
+++ b/src/test/java/com/meituan/lyrebird/test/TestFunctional.java
@@ -110,7 +110,7 @@ public class TestFunctional {
         FlowDetail flow = this.lyrebird.getFlowDetail("67ea0002-9566-41db-8178-ca0c2f82a71a");
 
         assertEquals("tester", flow.getRequest().getQuery().get("name"));
-        assertEquals(null, flow.getRequest().getData().get("age"));
+        assertEquals(null, flow.getRequest().getData());
         assertEquals("http://www.lyrebird.java.client.com/api/example", flow.getRequest().getUrl());
     }
 


### PR DESCRIPTION
…些，任何实现Map接口的数据类型都支持